### PR TITLE
Pull image rendering out of Landscape class.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ There are two way to select a camera:
 1) Set it in config: Create a property in config called `VIDEO_CAPTURE_INDEX`. Set it to the integer index of your camera, e.g. `VIDEO_CAPTURE_INDEX = 1`. This varies by system, so you may have to fiddle with it! 
 2) Use the camera selector: If `USE_CAMERA = true` and `VIDEO_CAPTURE_INDEX` is not set, Tinyland will open a camera selection screen. Press "n" and "p" to cycle through cameras. Press "s" to select.
 
+### Renderer selection
+The Tinyland library supports rendering your application with different renderer modules, as long as they implement the renderer.Renderer [abstract base class](https://docs.python.org/3/library/abc.html) and follow the naming convention `<your renderer name>_renderer.Renderer`. Choose the renderer by setting `RENDERER = <your renderer name>` in your config file. <br><br>For example, to choose the cv2_renderer module, put `RENDERER = "CV2"` in your config.
+
 ## Usage
 `python3 ./tinyland.py`
 

--- a/config-sample.toml
+++ b/config-sample.toml
@@ -23,3 +23,5 @@ USE_CAMERA = true
 VIDEO_FILE_PATH = "/Users/emma/Desktop/test.m4v"
 
 FLIP_PROJECTION = true # If offline, you probably want this to be false.
+
+RENDERER = "CV2"

--- a/context.py
+++ b/context.py
@@ -5,33 +5,55 @@ from collections import namedtuple
 XYPoint = namedtuple("XYPoint", ["x", "y"])
 
 
+# BGR color values
+BLACK = (0, 0, 0)
+WHITE = (255, 255, 255)
+BLUE = (255, 0, 0)
+GREEN = (0, 255, 0)
+RED = (0, 0, 255)
+CYAN = (255, 255, 0)
+MAGENTA = (255, 0, 255)
+YELLOW = (0, 255, 255)
+
+
 class Shape:
     """Base class for shapes to draw on the landscape."""
 
-    def __init__(self, x, y):
+    def __init__(self, x, y, color):
         self.center = XYPoint(x, y)
+        self.color = color
 
 
 class Circle(Shape):
 
-    def __init__(self, x, y, radius):
-        super().__init__(x, y)
+    def __init__(self, x, y, radius, color):
+        super().__init__(x, y, color)
         self.radius = radius
 
 
 class Rectangle(Shape):
 
-    def __init__(self, x, y, width, height):
-        super().__init__(x, y)
+    def __init__(self, x, y, width, height, rotation, color):
+        super().__init__(x, y, color)
         self.width = width
         self.height = height
+        self.rotation = rotation
 
 
 class Text(Shape):
 
-    def __init__(self, x, y, content):
-        super().__init__(x, y)
+    def __init__(self, x, y, content, color, size):
+        super().__init__(x, y, color)
         self.content = str(content)
+        self.size = size
+
+
+class Image(Shape):
+    def __init__(self, filepath, x, y, width, height):
+        super().__init__(x, y, color=BLACK)
+        self.width = width
+        self.height = height
+        self.filepath = filepath
 
 
 class DrawingContext:
@@ -51,12 +73,15 @@ class DrawingContext:
         self.height = height
         self.shapes = []
 
-    def rect(self, x, y, width, height):
-        self.shapes.append(Rectangle(x, y, width, height))
+    def rect(self, x, y, width, height, rotation=0, color=WHITE):
+        self.shapes.append(Rectangle(x, y, width, height, rotation, color))
 
-    def circle(self, x, y, radius):
-        self.shapes.append(Circle(x, y, radius))
+    def circle(self, x, y, radius, color=WHITE):
+        self.shapes.append(Circle(x, y, radius, color))
 
-    def text(self, x, y, content):
-        self.shapes.append(Text(x, y, content))
+    def text(self, x, y, content, color=WHITE, size=2):
+        self.shapes.append(Text(x, y, content, color, size))
+
+    def image(self, filepath, x, y, width, height):
+        self.shapes.append(Image(filepath, x, y, width, height))
 

--- a/cv2_renderer.py
+++ b/cv2_renderer.py
@@ -1,0 +1,113 @@
+import cv2
+import numpy as np
+
+import context
+import renderer
+
+
+class Renderer(renderer.Renderer):
+    WINDOW_TITLE = "Tinyland"
+
+    def __init__(self, width, height):
+        self.width = width
+        self.height = height
+
+    def setup(self):
+        """Create the OpenCV window to display images to."""
+        cv2.namedWindow(Renderer.WINDOW_TITLE)
+        # Allow window to be fullsized by both the OS window controls and OpenCV
+        cv2.setWindowProperty(Renderer.WINDOW_TITLE,
+                              cv2.WND_PROP_AUTOSIZE,
+                              cv2.WINDOW_NORMAL)
+
+    def toggle_fullscreen(self):
+        cur = cv2.getWindowProperty(Renderer.WINDOW_TITLE,
+                                    cv2.WND_PROP_FULLSCREEN)
+        if cur == cv2.WINDOW_NORMAL:
+            cv2.setWindowProperty(Renderer.WINDOW_TITLE,
+                                  cv2.WND_PROP_FULLSCREEN,
+                                  cv2.WINDOW_FULLSCREEN)
+        else:
+            cv2.setWindowProperty(Renderer.WINDOW_TITLE,
+                                  cv2.WND_PROP_FULLSCREEN,
+                                  cv2.WINDOW_NORMAL)
+
+    def show_calibration_markers(self):
+        image = np.zeros((self.height, self.width, 3), np.uint8)
+
+        # Display calibration markers until we find them
+        M_SZ = 40
+        marker = np.zeros((M_SZ, M_SZ, 3), dtype=np.uint8)
+        cv2.rectangle(marker, (0, 0), (M_SZ, M_SZ), (255, 255, 255), cv2.FILLED)
+        cv2.rectangle(marker, (10, 10), (M_SZ - 10, M_SZ - 10), (0, 0, 0),
+                      cv2.FILLED)
+
+        image[0:M_SZ, 0:M_SZ] = marker
+        marker = cv2.rotate(marker, cv2.ROTATE_90_CLOCKWISE)
+        image[0:M_SZ, self.width - M_SZ:self.width] = marker
+        marker = cv2.rotate(marker, cv2.ROTATE_90_CLOCKWISE)
+        image[self.height - M_SZ:self.height,
+        self.width - M_SZ:self.width] = marker
+        marker = cv2.rotate(marker, cv2.ROTATE_90_CLOCKWISE)
+        image[self.height - M_SZ:self.height, 0:M_SZ] = marker
+
+        self._display_frame(image)
+
+    def render(self, ctx):
+        """Display the draw context to the OpenCV window.
+
+        Process all shapes in the context and render resulting image.
+
+        Args:
+          ctx (context.DrawingContext): A context with shapes to draw
+        """
+        image = np.zeros((self.height, self.width, 3), np.uint8)
+        for shape in ctx.shapes:
+            if isinstance(shape, context.Rectangle):
+                x = int(shape.width / 2)
+                y = int(shape.height / 2)
+                rad = np.radians(shape.rotation)
+                rotation = np.array([[np.cos(rad), -np.sin(rad)],
+                                     [np.sin(rad), np.cos(rad)]])
+                translation = np.array([[shape.center.x], [shape.center.y]])
+                corners = np.array([[-x, x, x, -x], [y, y, -y, -y]])
+                transformed_corners = rotation.dot(corners) + translation
+                transformed_corners = transformed_corners.T.astype(int)
+                cv2.fillPoly(image, pts=[transformed_corners],
+                             color=shape.color)
+            elif isinstance(shape, context.Circle):
+                center = (int(shape.center.x), int(shape.center.y))
+                image = cv2.circle(image, center, int(shape.radius),
+                                   color=shape.color, thickness=-1)
+            elif isinstance(shape, context.Text):
+                center = (int(shape.center.x), int(shape.center.y))
+                image = cv2.putText(image, shape.content, center,
+                                    cv2.FONT_HERSHEY_SIMPLEX, shape.size,
+                                    shape.color, 3, cv2.LINE_AA)
+            elif isinstance(shape, context.Image):
+                file_image = cv2.imread(shape.filepath, cv2.IMREAD_UNCHANGED)
+                file_image = cv2.resize(file_image, (shape.width, shape.height))
+
+                y1 = int(shape.center.y - shape.height / 2)
+                y2 = int(y1 + file_image.shape[0])
+                x1 = int(shape.center.x - shape.width / 2)
+                x2 = int(x1 + file_image.shape[1])
+
+                rgba = cv2.cvtColor(file_image, cv2.COLOR_RGB2RGBA)
+                alpha_s = rgba[:, :, 3] / 255.0
+                alpha_l = 1.0 - alpha_s
+
+                image_save = image.copy()
+                for c in range(0, 3):
+                    try:
+                        image[y1:y2, x1:x2, c] = (
+                                    alpha_s * file_image[:, :, c] +
+                                    alpha_l * image[y1:y2, x1:x2, c])
+                    except ValueError:
+                        image = image_save
+
+        self._display_frame(image)
+
+    def _display_frame(self, image):
+        cv2.imshow(Renderer.WINDOW_TITLE, image)
+

--- a/renderer.py
+++ b/renderer.py
@@ -1,0 +1,17 @@
+from abc import ABC
+
+
+class Renderer(ABC):
+    """Abstract base class for a Tinyland renderer."""
+
+    def setup(self):
+        pass
+
+    def toggle_fullscreen(self):
+        pass
+
+    def show_calibration_markers(self):
+        pass
+
+    def render(self, ctx):
+        pass


### PR DESCRIPTION
We wanted to move away from relying on OpenCV as out rendering platform. In order to allow for different plugging in of renderers, this commit contains the following changes:
* Create renderer.Renderer Abstract Base Class as an interface for our different renderers
* Move all rendering logic out of Lanscape class and into CV2Renderer class that implements Renderer interface
* Allow user to specify renderer in config file
* Modify tinyland.run to reflect changes

Minor updates:
* Move keyevent handling out of Landscape class
* Add image support to DrawingContext
* Add color support to Drawingcontext